### PR TITLE
fix(http): correct errorHandler to return appropriate HTTP status codes

### DIFF
--- a/internal/server/http/server.go
+++ b/internal/server/http/server.go
@@ -55,12 +55,12 @@ func errorHandler(c *fiber.Ctx, err error) error {
 	var e *fiber.Error
 	if errors.As(err, &e) {
 		code = e.Code
-		return c.Status(code).JSON(HTTPError{
-			e.Message,
-			e.Code,
-			c.Path(),
-			c.Method(),
-		})
 	}
-	return nil
+
+	return c.Status(code).JSON(HTTPError{
+		Error:  err.Error(),
+		Code:   code,
+		Path:   c.Path(),
+		Method: c.Method(),
+	})
 }

--- a/internal/server/http/server.go
+++ b/internal/server/http/server.go
@@ -50,10 +50,12 @@ func (s *Server) Run(ctx context.Context) error {
 }
 
 func errorHandler(c *fiber.Ctx, err error) error {
-	c.Status(fiber.StatusInternalServerError)
+	code := fiber.StatusInternalServerError
+
 	var e *fiber.Error
 	if errors.As(err, &e) {
-		return c.JSON(HTTPError{
+		code = e.Code
+		return c.Status(code).JSON(HTTPError{
 			e.Message,
 			e.Code,
 			c.Path(),


### PR DESCRIPTION
The errorHandler now checks for fiber.Error types and returns the corresponding error code instead of always returning 500, based on your proposed changes. This improves error handling and provides clients with accurate HTTP status responses based on the error encountered.