### PR TITLE
Refactor/rename treenumber to number

### DIFF
--- a/internal/server/http/entities/tree.go
+++ b/internal/server/http/entities/tree.go
@@ -14,7 +14,7 @@ type TreeResponse struct {
 	Readonly       bool           `json:"readonly"`
 	PlantingYear   int32          `json:"planting_year"`
 	Species        string         `json:"species"`
-	Number         string         `json:"tree_number"`
+	Number         string         `json:"number"`
 	Latitude       float64        `json:"latitude"`
 	Longitude      float64        `json:"longitude"`
 	WateringStatus WateringStatus `json:"watering_status"`
@@ -31,7 +31,7 @@ type TreeCreateRequest struct {
 	Readonly      bool    `json:"readonly"`
 	PlantingYear  int32   `json:"planting_year"`
 	Species       string  `json:"species"`
-	Number        string  `json:"tree_number"`
+	Number        string  `json:"number"`
 	Latitude      float64 `json:"latitude"`
 	Longitude     float64 `json:"longitude"`
 	SensorID      *string `json:"sensor_id" validate:"optional"`
@@ -43,7 +43,7 @@ type TreeUpdateRequest struct {
 	Readonly      bool    `json:"readonly"`
 	PlantingYear  int32   `json:"planting_year"`
 	Species       string  `json:"species"`
-	Number        string  `json:"tree_number"`
+	Number        string  `json:"number"`
 	Latitude      float64 `json:"latitude"`
 	Longitude     float64 `json:"longitude"`
 	SensorID      *string `json:"sensor_id" validate:"optional"`

--- a/internal/server/http/handler/v1/fileimport/handler.go
+++ b/internal/server/http/handler/v1/fileimport/handler.go
@@ -203,10 +203,10 @@ func parseRowToTree(rowIdx int, row []string, headerIndexMap map[string]int) (*d
 		return nil, errorhandler.HandleError(errors.New("invalid 'Straße' value at row: " + strconv.Itoa(rowIdx)))
 	}
 
-	treeNumberIdx := headerIndexMap[expectedCSVHeaders[2]]
-	treeNumber := row[treeNumberIdx]
+	numberIdx := headerIndexMap[expectedCSVHeaders[2]]
+	number := row[numberIdx]
 
-	if treeNumber == "" {
+	if number == "" {
 		return nil, errorhandler.HandleError(errors.New("invalid 'BaumNr.' value at row: " + strconv.Itoa(rowIdx)))
 	}
 
@@ -241,7 +241,7 @@ func parseRowToTree(rowIdx int, row []string, headerIndexMap map[string]int) (*d
 
 	tree := &domain.TreeImport{
 		Area:         area,
-		Number:       treeNumber,
+		Number:       number,
 		Species:      species,
 		Latitude:     latitude,
 		Longitude:    longitude,

--- a/internal/service/domain/tree/tree.go
+++ b/internal/service/domain/tree/tree.go
@@ -93,7 +93,7 @@ func (s *TreeService) Create(ctx context.Context, treeCreate *entities.TreeCreat
 		tree.WithReadonly(treeCreate.Readonly),
 		tree.WithPlantingYear(treeCreate.PlantingYear),
 		tree.WithSpecies(treeCreate.Species),
-		tree.WithTreeNumber(treeCreate.Number),
+		tree.WithNumber(treeCreate.Number),
 		tree.WithLatitude(treeCreate.Latitude),
 		tree.WithLongitude(treeCreate.Longitude),
 	)
@@ -169,7 +169,7 @@ func (s *TreeService) Update(ctx context.Context, id int32, tu *entities.TreeUpd
 
 	fn = append(fn, tree.WithPlantingYear(tu.PlantingYear),
 		tree.WithSpecies(tu.Species),
-		tree.WithTreeNumber(tu.Number),
+		tree.WithNumber(tu.Number),
 		tree.WithLatitude(tu.Latitude),
 		tree.WithLongitude(tu.Longitude),
 		tree.WithDescription(tu.Description))

--- a/internal/storage/postgres/mapper/tree.go
+++ b/internal/storage/postgres/mapper/tree.go
@@ -12,7 +12,6 @@ import (
 // goverter:extend MapWateringStatus MapSoilCondition
 type InternalTreeRepoMapper interface {
 	// goverter:ignore Sensor Images TreeCluster
-	// goverter:map TreeNumber Number
 	FromSql(*sqlc.Tree) *entities.Tree
 	FromSqlList([]*sqlc.Tree) []*entities.Tree
 }

--- a/internal/storage/postgres/mapper/tree_test.go
+++ b/internal/storage/postgres/mapper/tree_test.go
@@ -28,7 +28,7 @@ func TestTreeMapper_FromSql(t *testing.T) {
 		assert.Equal(t, src.UpdatedAt.Time, got.UpdatedAt)
 		assert.Equal(t, src.PlantingYear, got.PlantingYear)
 		assert.Equal(t, src.Species, got.Species)
-		assert.Equal(t, src.TreeNumber, got.Number)
+		assert.Equal(t, src.Number, got.Number)
 		assert.Equal(t, src.Latitude, got.Latitude)
 		assert.Equal(t, src.Longitude, got.Longitude)
 		assert.Equal(t, src.WateringStatus, sqlc.WateringStatus(got.WateringStatus))
@@ -69,7 +69,7 @@ func TestTreeMapper_FromSqlList(t *testing.T) {
 			assert.Equal(t, src.UpdatedAt.Time, got[i].UpdatedAt)
 			assert.Equal(t, src.PlantingYear, got[i].PlantingYear)
 			assert.Equal(t, src.Species, got[i].Species)
-			assert.Equal(t, src.TreeNumber, got[i].Number)
+			assert.Equal(t, src.Number, got[i].Number)
 			assert.Equal(t, src.Latitude, got[i].Latitude)
 			assert.Equal(t, src.Longitude, got[i].Longitude)
 			assert.Equal(t, src.WateringStatus, sqlc.WateringStatus(got[i].WateringStatus))
@@ -102,7 +102,7 @@ var allTestTrees = []*sqlc.Tree{
 		WateringStatus: sqlc.WateringStatusGood,
 		Readonly:       true,
 		Description:    utils.P("Newly planted tree"),
-		TreeNumber:     "P 1234",
+		Number:     "P 1234",
 	},
 	{
 		ID:             2,
@@ -115,6 +115,6 @@ var allTestTrees = []*sqlc.Tree{
 		WateringStatus: sqlc.WateringStatusModerate,
 		Readonly:       true,
 		Description:    utils.P("Also newly planted tree"),
-		TreeNumber:     "P 2345",
+		Number:     "P 2345",
 	},
 }

--- a/internal/storage/postgres/mapper/tree_test.go
+++ b/internal/storage/postgres/mapper/tree_test.go
@@ -102,7 +102,7 @@ var allTestTrees = []*sqlc.Tree{
 		WateringStatus: sqlc.WateringStatusGood,
 		Readonly:       true,
 		Description:    utils.P("Newly planted tree"),
-		Number:     "P 1234",
+		Number:         "P 1234",
 	},
 	{
 		ID:             2,
@@ -115,6 +115,6 @@ var allTestTrees = []*sqlc.Tree{
 		WateringStatus: sqlc.WateringStatusModerate,
 		Readonly:       true,
 		Description:    utils.P("Also newly planted tree"),
-		Number:     "P 2345",
+		Number:         "P 2345",
 	},
 }

--- a/internal/storage/postgres/migrations/20241217134930_rename_tree_number_to_number.sql
+++ b/internal/storage/postgres/migrations/20241217134930_rename_tree_number_to_number.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE trees
+RENAME COLUMN tree_number TO number;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE trees
+RENAME COLUMN number TO tree_number;
+-- +goose StatementEnd

--- a/internal/storage/postgres/queries/trees.sql
+++ b/internal/storage/postgres/queries/trees.sql
@@ -38,7 +38,7 @@ UPDATE trees SET
   sensor_id = $3,
   planting_year = $4,
   species = $5,
-  tree_number = $6,
+  number = $6,
   readonly = $7,
   watering_status = $8,
   description = $9

--- a/internal/storage/postgres/queries/trees.sql
+++ b/internal/storage/postgres/queries/trees.sql
@@ -27,7 +27,7 @@ SELECT tree_clusters.* FROM tree_clusters JOIN trees ON tree_clusters.id = trees
 
 -- name: CreateTree :one
 INSERT INTO trees (
-  tree_cluster_id, sensor_id, planting_year, species, tree_number, readonly, description, watering_status, latitude, longitude
+  tree_cluster_id, sensor_id, planting_year, species, number, readonly, description, watering_status, latitude, longitude
 ) VALUES (
   $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
 ) RETURNING id;

--- a/internal/storage/postgres/seed/99_demo_data.sql
+++ b/internal/storage/postgres/seed/99_demo_data.sql
@@ -36,7 +36,7 @@ VALUES
     ('sensor-4', 'online', 54.82042158396298, 9.488535474607701, ST_SetSRID(ST_MakePoint(54.82042158396298, 9.488535474607701), 4326));
 
 
-INSERT INTO trees (tree_cluster_id, sensor_id, planting_year, species, tree_number, latitude, longitude, geometry, readonly, watering_status, description)
+INSERT INTO trees (tree_cluster_id, sensor_id, planting_year, species, number, latitude, longitude, geometry, readonly, watering_status, description)
 VALUES 
   (1, 'sensor-1', 2021, 'Quercus robur', 1005, 54.82124518093376, 9.485702120628517, ST_SetSRID(ST_MakePoint(54.82124518093376, 9.485702120628517), 4326), true, 'unknown', 'Dieser Baum wurde im August das lezte mal gestuzt'),
   (1, NULL, 2022, 'Quercus robur', 1006, 54.8215076622281, 9.487153277881877, ST_SetSRID(ST_MakePoint(54.8215076622281, 9.487153277881877), 4326), true, 'good', ''),

--- a/internal/storage/postgres/seed/test/tree/02_trees.sql
+++ b/internal/storage/postgres/seed/test/tree/02_trees.sql
@@ -37,7 +37,7 @@ VALUES
 
 ALTER SEQUENCE images_id_seq RESTART WITH 5;
 
-INSERT INTO trees (id, tree_cluster_id, sensor_id, planting_year, species, tree_number, latitude, longitude, geometry, readonly, watering_status, description)
+INSERT INTO trees (id, tree_cluster_id, sensor_id, planting_year, species, number, latitude, longitude, geometry, readonly, watering_status, description)
 VALUES
     (1, 1, 'sensor-1', 2021, 'Quercus robur', 1005, 54.82124518093376, 9.485702120628517, ST_SetSRID(ST_MakePoint(54.82124518093376, 9.485702120628517), 4326), true, 'unknown', 'Sample description 1'),
     (2, 1, NULL, 2022, 'Quercus robur', 1006, 54.8215076622281, 9.487153277881877, ST_SetSRID(ST_MakePoint(54.8215076622281, 9.487153277881877), 4326), true, 'good', 'Sample description 2'),

--- a/internal/storage/postgres/seed/test/treecluster/02_treecluster.sql
+++ b/internal/storage/postgres/seed/test/treecluster/02_treecluster.sql
@@ -28,7 +28,7 @@ INSERT INTO sensors (id, status, latitude, longitude, geometry)
 VALUES
     ('sensor-4', 'online', 54.82078826498143, 9.489684366114483, ST_SetSRID(ST_MakePoint(54.82078826498143, 9.489684366114483), 4326));
 
-INSERT INTO trees (id, tree_cluster_id, sensor_id, planting_year, species, tree_number, latitude, longitude, geometry, readonly, watering_status, description)
+INSERT INTO trees (id, tree_cluster_id, sensor_id, planting_year, species, number, latitude, longitude, geometry, readonly, watering_status, description)
 VALUES 
   (1, 1, 'sensor-1', 2021, 'Quercus robur', 1005, 54.82124518093376, 9.485702120628517, ST_SetSRID(ST_MakePoint(54.82124518093376, 9.485702120628517), 4326), true, 'unknown', 'Dieser Baum wurde im August das lezte mal gestuzt'),
   (2, 1, NULL, 2022, 'Quercus robur', 1006, 54.8215076622281, 9.487153277881877, ST_SetSRID(ST_MakePoint(54.8215076622281, 9.487153277881877), 4326), true, 'good', ''),

--- a/internal/storage/postgres/seed/test/watering_plan/03_treecluster.sql
+++ b/internal/storage/postgres/seed/test/watering_plan/03_treecluster.sql
@@ -24,7 +24,7 @@ VALUES
     ('sensor-4', 'online', 54.82078826498143, 9.489684366114483, ST_SetSRID(ST_MakePoint(54.82078826498143, 9.489684366114483), 4326));
 
 
-INSERT INTO trees (id, tree_cluster_id, sensor_id, planting_year, species, tree_number, latitude, longitude, geometry, readonly, watering_status, description)
+INSERT INTO trees (id, tree_cluster_id, sensor_id, planting_year, species, number, latitude, longitude, geometry, readonly, watering_status, description)
 VALUES 
   (1, 1, 'sensor-1', 2021, 'Quercus robur', 1005, 54.82124518093376, 9.485702120628517, ST_SetSRID(ST_MakePoint(54.82124518093376, 9.485702120628517), 4326), true, 'unknown', 'Dieser Baum wurde im August das lezte mal gestuzt'),
   (2, 1, NULL, 2022, 'Quercus robur', 1006, 54.8215076622281, 9.487153277881877, ST_SetSRID(ST_MakePoint(54.8215076622281, 9.487153277881877), 4326), true, 'good', ''),

--- a/internal/storage/postgres/tree/create.go
+++ b/internal/storage/postgres/tree/create.go
@@ -93,7 +93,7 @@ func (r *TreeRepository) createEntity(ctx context.Context, entity *entities.Tree
 		Longitude:      entity.Longitude,
 		WateringStatus: sqlc.WateringStatus(entity.WateringStatus),
 		Description:    &entity.Description,
-		Number:     entity.Number,
+		Number:         entity.Number,
 	}
 
 	id, err := r.store.CreateTree(ctx, &args)

--- a/internal/storage/postgres/tree/create.go
+++ b/internal/storage/postgres/tree/create.go
@@ -93,7 +93,7 @@ func (r *TreeRepository) createEntity(ctx context.Context, entity *entities.Tree
 		Longitude:      entity.Longitude,
 		WateringStatus: sqlc.WateringStatus(entity.WateringStatus),
 		Description:    &entity.Description,
-		TreeNumber:     entity.Number,
+		Number:     entity.Number,
 	}
 
 	id, err := r.store.CreateTree(ctx, &args)

--- a/internal/storage/postgres/tree/create_test.go
+++ b/internal/storage/postgres/tree/create_test.go
@@ -58,7 +58,7 @@ func TestTreeRepository_Create(t *testing.T) {
 		// when
 		got, err := r.Create(context.Background(),
 			WithSpecies("Oak"),
-			WithTreeNumber("T001"),
+			WithNumber("T001"),
 			WithPlantingYear(2023),
 			WithLatitude(54.801539),
 			WithLongitude(9.446741),
@@ -174,7 +174,7 @@ func TestTreeRepository_CreateAndLinkImages(t *testing.T) {
 		// when
 		tree, createErr := r.CreateAndLinkImages(context.Background(),
 			WithSpecies("Oak"),
-			WithTreeNumber("T001"),
+			WithNumber("T001"),
 			WithLatitude(54.801539),
 			WithLongitude(9.446741),
 			WithPlantingYear(2023),
@@ -220,7 +220,7 @@ func TestTreeRepository_CreateAndLinkImages(t *testing.T) {
 		// when
 		tree, createErr := r.CreateAndLinkImages(context.Background(),
 			WithSpecies("Oak"),
-			WithTreeNumber("T001"),
+			WithNumber("T001"),
 			WithLatitude(54.801539),
 			WithLongitude(9.446741),
 			WithPlantingYear(2023),

--- a/internal/storage/postgres/tree/trees.go
+++ b/internal/storage/postgres/tree/trees.go
@@ -87,7 +87,7 @@ func WithLongitude(long float64) entities.EntityFunc[entities.Tree] {
 	}
 }
 
-func WithTreeNumber(number string) entities.EntityFunc[entities.Tree] {
+func WithNumber(number string) entities.EntityFunc[entities.Tree] {
 	return func(t *entities.Tree) {
 		t.Number = number
 	}

--- a/internal/storage/postgres/tree/update.go
+++ b/internal/storage/postgres/tree/update.go
@@ -70,7 +70,7 @@ func (r *TreeRepository) updateEntity(ctx context.Context, t *entities.Tree) err
 		Species:        t.Species,
 		Readonly:       t.Readonly,
 		PlantingYear:   t.PlantingYear,
-		TreeNumber:     t.Number,
+		Number:     t.Number,
 		SensorID:       sensorID,
 		TreeClusterID:  treeClusterID,
 		WateringStatus: sqlc.WateringStatus(t.WateringStatus),

--- a/internal/storage/postgres/tree/update.go
+++ b/internal/storage/postgres/tree/update.go
@@ -70,7 +70,7 @@ func (r *TreeRepository) updateEntity(ctx context.Context, t *entities.Tree) err
 		Species:        t.Species,
 		Readonly:       t.Readonly,
 		PlantingYear:   t.PlantingYear,
-		Number:     t.Number,
+		Number:         t.Number,
 		SensorID:       sensorID,
 		TreeClusterID:  treeClusterID,
 		WateringStatus: sqlc.WateringStatus(t.WateringStatus),

--- a/internal/storage/postgres/tree/update_test.go
+++ b/internal/storage/postgres/tree/update_test.go
@@ -28,7 +28,7 @@ func TestTreeRepository_Update(t *testing.T) {
 			context.Background(),
 			treeID,
 			WithSpecies(newSpecies),
-			WithTreeNumber(newNumber),
+			WithNumber(newNumber),
 			WithLatitude(newLatitude),
 			WithLongitude(newLongitude),
 			WithPlantingYear(newPlantingYear),


### PR DESCRIPTION
I really did not like it that in the storage layer it was `TreeNumber` and in the server layer `Number` and then again in the frontend its `tree.treeNumber`. I unified everything to `number`. After this is merged we also need to update the frontend.