### PR TITLE
Fix/update watering status of tree cluster on sensor change

### DIFF
--- a/internal/entities/events.go
+++ b/internal/entities/events.go
@@ -42,12 +42,14 @@ func NewEventUpdateTree(prev, newTree, prevOfSensor *Tree) EventUpdateTree {
 type EventCreateTree struct {
 	BasicEvent
 	New *Tree
+	PrevOfSensor *Tree
 }
 
-func NewEventCreateTree(newTree *Tree) EventCreateTree {
+func NewEventCreateTree(newTree *Tree, prevOfSensor *Tree) EventCreateTree {
 	return EventCreateTree{
 		BasicEvent: BasicEvent{eventType: EventTypeCreateTree},
 		New:        newTree,
+		PrevOfSensor: prevOfSensor,
 	}
 }
 

--- a/internal/entities/events.go
+++ b/internal/entities/events.go
@@ -25,30 +25,30 @@ func (e BasicEvent) Type() EventType {
 
 type EventUpdateTree struct {
 	BasicEvent
-	Prev *Tree
-	New  *Tree
+	Prev         *Tree
+	New          *Tree
 	PrevOfSensor *Tree
 }
 
 func NewEventUpdateTree(prev, newTree, prevOfSensor *Tree) EventUpdateTree {
 	return EventUpdateTree{
-		BasicEvent: BasicEvent{eventType: EventTypeUpdateTree},
-		Prev:       prev,
-		New:        newTree,
+		BasicEvent:   BasicEvent{eventType: EventTypeUpdateTree},
+		Prev:         prev,
+		New:          newTree,
 		PrevOfSensor: prevOfSensor,
 	}
 }
 
 type EventCreateTree struct {
 	BasicEvent
-	New *Tree
+	New          *Tree
 	PrevOfSensor *Tree
 }
 
-func NewEventCreateTree(newTree *Tree, prevOfSensor *Tree) EventCreateTree {
+func NewEventCreateTree(newTree, prevOfSensor *Tree) EventCreateTree {
 	return EventCreateTree{
-		BasicEvent: BasicEvent{eventType: EventTypeCreateTree},
-		New:        newTree,
+		BasicEvent:   BasicEvent{eventType: EventTypeCreateTree},
+		New:          newTree,
 		PrevOfSensor: prevOfSensor,
 	}
 }

--- a/internal/entities/events.go
+++ b/internal/entities/events.go
@@ -27,13 +27,15 @@ type EventUpdateTree struct {
 	BasicEvent
 	Prev *Tree
 	New  *Tree
+	PrevOfSensor *Tree
 }
 
-func NewEventUpdateTree(prev, newTree *Tree) EventUpdateTree {
+func NewEventUpdateTree(prev, newTree, prevOfSensor *Tree) EventUpdateTree {
 	return EventUpdateTree{
 		BasicEvent: BasicEvent{eventType: EventTypeUpdateTree},
 		Prev:       prev,
 		New:        newTree,
+		PrevOfSensor: prevOfSensor,
 	}
 }
 

--- a/internal/service/domain/tree/handle_new_sensor_data.go
+++ b/internal/service/domain/tree/handle_new_sensor_data.go
@@ -36,6 +36,6 @@ func (s *TreeService) HandleNewSensorData(ctx context.Context, event *entities.E
 
 	log.Info("watering status of tree has been successfully updated", "tree_id", t.ID, "prev_status", t.WateringStatus, "new_status", status)
 
-	s.publishUpdateTreeEvent(ctx, t, newTree)
+	s.publishUpdateTreeEvent(ctx, t, newTree, nil)
 	return nil
 }

--- a/internal/service/domain/tree/tree_test.go
+++ b/internal/service/domain/tree/tree_test.go
@@ -790,7 +790,7 @@ func TestTreeService_EventSystem(t *testing.T) {
 
 		// EventSystem
 		eventManager := worker.NewEventManager(entities.EventTypeCreateTree)
-		expectedEvent := entities.NewEventCreateTree(&expectedTree)
+		expectedEvent := entities.NewEventCreateTree(&expectedTree, nil)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go eventManager.Run(ctx)
@@ -829,7 +829,7 @@ func TestTreeService_EventSystem(t *testing.T) {
 
 		// Event
 		eventManager := worker.NewEventManager(entities.EventTypeUpdateTree)
-		expectedEvent := entities.NewEventUpdateTree(&prevTree, &expectedTree)
+		expectedEvent := entities.NewEventUpdateTree(&prevTree, &expectedTree, nil)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go eventManager.Run(ctx)

--- a/internal/service/domain/tree/tree_test.go
+++ b/internal/service/domain/tree/tree_test.go
@@ -260,6 +260,7 @@ func TestTreeService_Create(t *testing.T) {
 		svc := tree.NewTreeService(treeRepo, sensorRepo, imageRepo, treeClusterRepo, globalEventManager)
 
 		expectedTree := TestTreesList[0]
+		expectedPrevSensorTree := TestTreesList[1]
 		expectedCluster := TestTreeClusters[0]
 		expectedSensor := TestSensors[0]
 
@@ -275,7 +276,7 @@ func TestTreeService_Create(t *testing.T) {
 				testTree := &entities.Tree{}
 
 				treeClusterRepo.EXPECT().GetByID(ctx, *TestTreeCreate.TreeClusterID).Return(expectedCluster, nil)
-
+				treeRepo.EXPECT().GetBySensorID(ctx, expectedSensor.ID).Return(expectedPrevSensorTree, nil)
 				sensorRepo.EXPECT().GetByID(ctx, *TestTreeCreate.SensorID).Return(expectedSensor, nil)
 
 				success, err := fn(testTree)
@@ -407,6 +408,7 @@ func TestTreeService_Create(t *testing.T) {
 		svc := tree.NewTreeService(treeRepo, sensorRepo, imageRepo, treeClusterRepo, globalEventManager)
 
 		expectedCluster := TestTreeClusters[0]
+		expectedPrevSensorTree := TestTreesList[1]
 		expectedSensor := TestSensors[0]
 		expectedError := errors.New("tree creation failed")
 
@@ -422,7 +424,7 @@ func TestTreeService_Create(t *testing.T) {
 				testTree := &entities.Tree{}
 
 				treeClusterRepo.EXPECT().GetByID(ctx, *TestTreeCreate.TreeClusterID).Return(expectedCluster, nil)
-
+				treeRepo.EXPECT().GetBySensorID(ctx, expectedSensor.ID).Return(expectedPrevSensorTree, nil)
 				sensorRepo.EXPECT().GetByID(ctx, *TestTreeCreate.SensorID).Return(expectedSensor, nil)
 
 				success, err := fn(testTree)
@@ -568,6 +570,7 @@ func TestTreeService_Update(t *testing.T) {
 		treeCluster := TestTreeClusters[0]
 		currentTree.TreeCluster = treeCluster
 		sensor := TestSensors[0]
+		expectedPrevSensorTree := TestTreesList[1]
 		currentTree.Sensor = sensor
 
 		if TestTreeUpdate.TreeClusterID == nil {
@@ -584,7 +587,7 @@ func TestTreeService_Update(t *testing.T) {
 				testTree := *currentTree
 
 				treeClusterRepo.EXPECT().GetByID(ctx, *TestTreeUpdate.TreeClusterID).Return(treeCluster, nil)
-
+				treeRepo.EXPECT().GetBySensorID(ctx, sensor.ID).Return(expectedPrevSensorTree, nil)
 				sensorRepo.EXPECT().GetByID(ctx, *TestTreeUpdate.SensorID).Return(sensor, nil)
 
 				success, err := fn(&testTree)
@@ -743,15 +746,16 @@ func TestTreeService_Update(t *testing.T) {
 		treeCluster := TestTreeClusters[0]
 		currentTree.TreeCluster = treeCluster
 		sensor := TestSensors[0]
+		expectedPrevSensorTree := TestTreesList[1]
 		currentTree.Sensor = sensor
 
 		treeRepo.EXPECT().GetByID(ctx, id).Return(currentTree, nil)
-
 		treeRepo.EXPECT().Update(ctx, id, mock.Anything).RunAndReturn(
 			func(ctx context.Context, id int32, fn func(*entities.Tree) (bool, error)) (*entities.Tree, error) {
 				testTree := *currentTree
 
 				treeClusterRepo.EXPECT().GetByID(ctx, *TestTreeUpdate.TreeClusterID).Return(treeCluster, nil)
+				treeRepo.EXPECT().GetBySensorID(ctx, sensor.ID).Return(expectedPrevSensorTree, nil)
 				sensorRepo.EXPECT().GetByID(ctx, *TestTreeUpdate.SensorID).Return(sensor, nil)
 
 				success, err := fn(&testTree)

--- a/internal/service/domain/treecluster/handle_tree_update.go
+++ b/internal/service/domain/treecluster/handle_tree_update.go
@@ -2,7 +2,6 @@ package treecluster
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/green-ecolution/green-ecolution-backend/internal/entities"
 	"github.com/green-ecolution/green-ecolution-backend/internal/logger"
@@ -114,8 +113,6 @@ func (s *TreeClusterService) updateWateringStatusOfPrevTreeCluster(ctx context.C
 		return nil
 	}
 
-	fmt.Println("UPDATE_WATERING_STATUS_OF_PREV_TREE_CLUSTER")
-	
 	wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, prevTc.ID)
 	if err != nil {
 		log.Error("could not update watering status", "error", err)
@@ -125,7 +122,7 @@ func (s *TreeClusterService) updateWateringStatusOfPrevTreeCluster(ctx context.C
 		tc.WateringStatus = wateringStatus
 		return true, nil
 	}
-	
+
 	if err := s.treeClusterRepo.Update(ctx, prevTc.ID, updateFn); err == nil {
 		log.Info("successfully updated watering status of previous tree cluster", "cluster_id", prevTc.ID)
 		return s.publishUpdateEvent(ctx, prevTc)

--- a/internal/service/domain/treecluster/handle_tree_update_test.go
+++ b/internal/service/domain/treecluster/handle_tree_update_test.go
@@ -92,6 +92,55 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 		}
 	})
 
+	t.Run("should only update watering status to unknown of previous tree cluster linked to sensor", func(t *testing.T) {
+		clusterRepo, _, _, eventManager, svc := setupTest(t)
+
+		// event
+		_, ch, _ := eventManager.Subscribe(entities.EventTypeUpdateTreeCluster)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go eventManager.Run(ctx)
+
+		prevTree := entities.Tree{
+			TreeCluster: &prevTc,
+			Latitude:    *prevTc.Latitude,
+			Longitude:   *prevTc.Longitude,
+		}
+
+		updatedTree := entities.Tree{
+			TreeCluster: &prevTc,
+			Latitude:    *prevTc.Latitude,
+			Longitude:   *prevTc.Longitude,
+		}
+
+		event := entities.NewEventUpdateTree(&prevTree, &updatedTree, &prevTreeOfSensor)
+
+		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(2)).Return([]*entities.SensorData{}, nil)
+		clusterRepo.EXPECT().Update(mock.Anything, int32(2), mock.Anything).RunAndReturn(func(ctx context.Context, i int32, f func(*entities.TreeCluster) (bool, error)) error {
+			cluster := entities.TreeCluster{}
+			_, err := f(&cluster)
+			assert.NoError(t, err)
+			assert.Equal(t, entities.WateringStatusUnknown, cluster.WateringStatus)
+			return nil
+		})
+		clusterRepo.EXPECT().GetByID(mock.Anything, int32(2)).Return(&prevTreeClusterOfSensor, nil)
+
+		// when
+		err := svc.HandleUpdateTree(context.Background(), &event)
+
+		// then
+		assert.NoError(t, err)
+		select {
+		case recievedEvent, ok := <-ch:
+			assert.True(t, ok)
+			e := recievedEvent.(entities.EventUpdateTreeCluster)
+			assert.Equal(t, e.Prev, &prevTreeClusterOfSensor)
+			assert.Equal(t, e.New, &prevTreeClusterOfSensor)
+		case <-time.After(1 * time.Second):
+			t.Fatal("event was not received")
+		}
+	})
+
 	t.Run("should not update tree cluster if treeclusters in event are nil", func(t *testing.T) {
 		clusterRepo, _, regionRepo, eventManager, svc := setupTest(t)
 
@@ -321,11 +370,33 @@ var updatedTree = entities.Tree{
 	},
 }
 
+var prevTreeOfSensor = entities.Tree{
+	ID:           2,
+	TreeCluster:  &prevTreeClusterOfSensor,
+	Number:       "T002",
+	Latitude:     54.811733806341856,
+	Longitude:    9.482958846410169,
+	PlantingYear: int32(time.Now().Year() - 2),
+	Sensor: &entities.Sensor{
+		ID: "sensor-1",
+	},
+}
+
 var updatedTc = entities.TreeCluster{
 	ID: 1,
 	Region: &entities.Region{
 		ID:   2,
 		Name: "Mürwik",
+	},
+	Latitude:  utils.P(54.811733806341856),
+	Longitude: utils.P(9.482958846410169),
+}
+
+var prevTreeClusterOfSensor = entities.TreeCluster{
+	ID: 2,
+	Region: &entities.Region{
+		ID:   3,
+		Name: "Fuerlund",
 	},
 	Latitude:  utils.P(54.811733806341856),
 	Longitude: utils.P(9.482958846410169),

--- a/internal/service/domain/treecluster/handle_tree_update_test.go
+++ b/internal/service/domain/treecluster/handle_tree_update_test.go
@@ -26,7 +26,7 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 		defer cancel()
 		go eventManager.Run(ctx)
 
-		event := entities.NewEventUpdateTree(&prevTree, &updatedTree)
+		event := entities.NewEventUpdateTree(&prevTree, &updatedTree, nil)
 
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(1)).Return(allLatestSensorData, nil)
 		treeRepo.EXPECT().GetBySensorIDs(mock.Anything, "sensor-1").Return([]*entities.Tree{&updatedTree}, nil)
@@ -64,7 +64,7 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 		defer cancel()
 		go eventManager.Run(ctx)
 
-		event := entities.NewEventUpdateTree(&prevTree, &updatedTree)
+		event := entities.NewEventUpdateTree(&prevTree, &updatedTree, nil)
 
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(1)).Return(nil, storage.ErrSensorNotFound)
 		clusterRepo.EXPECT().Update(mock.Anything, int32(1), mock.Anything).RunAndReturn(func(ctx context.Context, i int32, f func(*entities.TreeCluster) (bool, error)) error {
@@ -107,7 +107,7 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 		updatedWithoutCluster := updatedTree
 		updatedWithoutCluster.TreeCluster = nil
 
-		event := entities.NewEventUpdateTree(&prevWithoutCluster, &updatedWithoutCluster)
+		event := entities.NewEventUpdateTree(&prevWithoutCluster, &updatedWithoutCluster, nil)
 
 		// when
 		err := svc.HandleUpdateTree(context.Background(), &event)
@@ -147,7 +147,7 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 			Longitude:   *prevTc.Longitude,
 		}
 
-		event := entities.NewEventUpdateTree(&prevTree, &updatedTree)
+		event := entities.NewEventUpdateTree(&prevTree, &updatedTree, nil)
 
 		// when
 		err := svc.HandleUpdateTree(context.Background(), &event)
@@ -186,7 +186,7 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 		}
 		updatedTree.TreeCluster = &newTc
 
-		event := entities.NewEventUpdateTree(&prevTree, &updatedTree)
+		event := entities.NewEventUpdateTree(&prevTree, &updatedTree, nil)
 
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(2)).Return(nil, storage.ErrSensorNotFound)
 		clusterRepo.EXPECT().Update(mock.Anything, int32(1), mock.Anything).Return(nil)
@@ -214,7 +214,7 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 	t.Run("should listen on create new tree event", func(t *testing.T) {
 		// given
 		eventManager := worker.NewEventManager(entities.EventTypeCreateTree)
-		event := entities.NewEventCreateTree(&updatedTree)
+		event := entities.NewEventCreateTree(&updatedTree, nil)
 
 		_, ch, _ := eventManager.Subscribe(entities.EventTypeCreateTree)
 		ctx, cancel := context.WithCancel(context.Background())
@@ -237,7 +237,7 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 	t.Run("should listen on update tree event", func(t *testing.T) {
 		// given
 		eventManager := worker.NewEventManager(entities.EventTypeUpdateTree)
-		event := entities.NewEventUpdateTree(&prevTree, &updatedTree)
+		event := entities.NewEventUpdateTree(&prevTree, &updatedTree, nil)
 
 		_, ch, _ := eventManager.Subscribe(entities.EventTypeUpdateTree)
 		ctx, cancel := context.WithCancel(context.Background())

--- a/internal/worker/subscriber/subscriber_test.go
+++ b/internal/worker/subscriber/subscriber_test.go
@@ -15,7 +15,7 @@ func TestUpdateTreeSubsciber(t *testing.T) {
 		// given
 		tcSvc := svcMock.NewMockTreeClusterService(t)
 		sub := NewUpdateTreeSubscriber(tcSvc)
-		event := entities.NewEventUpdateTree(nil, nil)
+		event := entities.NewEventUpdateTree(nil, nil, nil)
 
 		tcSvc.EXPECT().HandleUpdateTree(mock.Anything, &event).Return(nil)
 
@@ -32,7 +32,7 @@ func TestUpdateTreeSubsciber(t *testing.T) {
 		// given
 		tcSvc := svcMock.NewMockTreeClusterService(t)
 		sub := NewCreateTreeSubscriber(tcSvc)
-		event := entities.NewEventCreateTree(nil)
+		event := entities.NewEventCreateTree(nil, nil)
 
 		tcSvc.EXPECT().HandleCreateTree(mock.Anything, &event).Return(nil)
 


### PR DESCRIPTION
Close https://github.com/green-ecolution/green-ecolution-backend/issues/387

How to test it (frontend-wise):
- select a tree cluster where one linked tree in the tree cluster has a sensor. Check which sensor is linked 
- select another tree cluster, select one random linked tree in the tree cluster and link the sensor to it that is currently linked to the tree in the first cluster and save your changes
- check if both watering status values are updated. the tree cluster without any sensors should have now »unknown« as a watering status value