### PR TITLE
refactor: unify param types of pagination values in swagger

### DIFF
--- a/internal/entities/treecluster.go
+++ b/internal/entities/treecluster.go
@@ -53,7 +53,7 @@ type TreeClusterUpdate struct {
 }
 
 type TreeClusterQuery struct {
-	WateringStatus []WateringStatus `query:"status"`
-	Region         []string         `query:"region"`
+	WateringStatuses []WateringStatus `query:"watering_statuses"`
+	Regions          []string         `query:"regions"`
 	Query
 }

--- a/internal/entities/watering_status.go
+++ b/internal/entities/watering_status.go
@@ -40,6 +40,8 @@ func ParseWateringStatus(status string) ([]WateringStatus, error) {
 
 func parseSingleWateringStatus(status string) (WateringStatus, error) {
 	switch status {
+	case string(WateringStatusJustWatered):
+		return WateringStatusJustWatered, nil
 	case string(WateringStatusGood):
 		return WateringStatusGood, nil
 	case string(WateringStatusModerate):

--- a/internal/server/http/handler/v1/region/handler.go
+++ b/internal/server/http/handler/v1/region/handler.go
@@ -19,8 +19,8 @@ import (
 // @Success		200		{object}	entities.RegionListResponse
 // @Failure		400		{object}	HTTPError
 // @Failure		500		{object}	HTTPError
-// @Param			page	query		string	false	"Page"
-// @Param			limit	query		string	false	"Limit"
+// @Param			page	query		int	false	"Page"
+// @Param			limit	query		int	false	"Limit"
 // @Router			/v1/region [get]
 // @Security		Keycloak
 func GetAllRegions(svc service.RegionService) fiber.Handler {

--- a/internal/server/http/handler/v1/tree/handler.go
+++ b/internal/server/http/handler/v1/tree/handler.go
@@ -18,22 +18,22 @@ var (
 	sensorMapper = generated.SensorHTTPMapperImpl{}
 )
 
-// @Summary		Get all trees
-// @Description	Get all trees
-// @Id				get-all-trees
-// @Tags			Tree
-// @Produce		json
-// @Success		200	{object}	entities.TreeListResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/tree [get]
-// @Param			page		query	string	false	"Page"
-// @Param			limit		query	string	false	"Limit"
-// @Param			provider	query	string	false	"Provider"
-// @Security		Keycloak
+//	@Summary		Get all trees
+//	@Description	Get all trees
+//	@Id				get-all-trees
+//	@Tags			Tree
+//	@Produce		json
+//	@Success		200	{object}	entities.TreeListResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/tree [get]
+//	@Param			page		query	int		false	"Page"
+//	@Param			limit		query	int		false	"Limit"
+//	@Param			provider	query	string	false	"Provider"
+//	@Security		Keycloak
 func GetAllTrees(svc service.TreeService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -60,20 +60,20 @@ func GetAllTrees(svc service.TreeService) fiber.Handler {
 	}
 }
 
-// @Summary		Get tree by ID
-// @Description	Get tree by ID
-// @Id				get-trees
-// @Tags			Tree
-// @Produce		json
-// @Success		200	{object}	entities.TreeResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/tree/{tree_id} [get]
-// @Param			tree_id	path	int	false	"Tree ID"
-// @Security		Keycloak
+//	@Summary		Get tree by ID
+//	@Description	Get tree by ID
+//	@Id				get-trees
+//	@Tags			Tree
+//	@Produce		json
+//	@Success		200	{object}	entities.TreeResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/tree/{tree_id} [get]
+//	@Param			tree_id	path	int	false	"Tree ID"
+//	@Security		Keycloak
 func GetTreeByID(svc service.TreeService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -96,20 +96,20 @@ func GetTreeByID(svc service.TreeService) fiber.Handler {
 	}
 }
 
-// @Summary		Get tree by sensor ID
-// @Description	Get tree by sensor ID
-// @Id				get-tree-by-sensor-id
-// @Tags			Tree Sensor
-// @Produce		json
-// @Success		200	{object}	entities.TreeResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/tree/sensor/{sensor_id} [get]
-// @Param			sensor_id	path	string	false	"Sensor ID"
-// @Security		Keycloak
+//	@Summary		Get tree by sensor ID
+//	@Description	Get tree by sensor ID
+//	@Id				get-tree-by-sensor-id
+//	@Tags			Tree Sensor
+//	@Produce		json
+//	@Success		200	{object}	entities.TreeResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/tree/sensor/{sensor_id} [get]
+//	@Param			sensor_id	path	string	false	"Sensor ID"
+//	@Security		Keycloak
 func GetTreeBySensorID(svc service.TreeService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -125,20 +125,20 @@ func GetTreeBySensorID(svc service.TreeService) fiber.Handler {
 	}
 }
 
-// @Summary		Create tree
-// @Description	Create tree
-// @Id				create-tree
-// @Tags			Tree
-// @Produce		json
-// @Success		200	{object}	entities.TreeResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/tree [post]
-// @Security		Keycloak
-// @Param			body	body	entities.TreeCreateRequest	true	"Tree to create"
+//	@Summary		Create tree
+//	@Description	Create tree
+//	@Id				create-tree
+//	@Tags			Tree
+//	@Produce		json
+//	@Success		200	{object}	entities.TreeResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/tree [post]
+//	@Security		Keycloak
+//	@Param			body	body	entities.TreeCreateRequest	true	"Tree to create"
 func CreateTree(svc service.TreeService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -158,21 +158,21 @@ func CreateTree(svc service.TreeService) fiber.Handler {
 	}
 }
 
-// @Summary		Update tree
-// @Description	Update tree
-// @Id				update-tree
-// @Tags			Tree
-// @Produce		json
-// @Success		200	{object}	entities.TreeResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/tree/{tree_id} [put]
-// @Security		Keycloak
-// @Param			tree_id	path	int							false	"Tree ID"
-// @Param			body	body	entities.TreeUpdateRequest	true	"Tree to update"
+//	@Summary		Update tree
+//	@Description	Update tree
+//	@Id				update-tree
+//	@Tags			Tree
+//	@Produce		json
+//	@Success		200	{object}	entities.TreeResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/tree/{tree_id} [put]
+//	@Security		Keycloak
+//	@Param			tree_id	path	int							false	"Tree ID"
+//	@Param			body	body	entities.TreeUpdateRequest	true	"Tree to update"
 func UpdateTree(svc service.TreeService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -195,20 +195,20 @@ func UpdateTree(svc service.TreeService) fiber.Handler {
 	}
 }
 
-// @Summary		Delete tree
-// @Description	Delete tree
-// @Id				delete-tree
-// @Tags			Tree
-// @Produce		json
-// @Success		204
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/tree/{tree_id} [delete]
-// @Param			tree_id	path	int	false	"Tree ID"
-// @Security		Keycloak
+//	@Summary		Delete tree
+//	@Description	Delete tree
+//	@Id				delete-tree
+//	@Tags			Tree
+//	@Produce		json
+//	@Success		204
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/tree/{tree_id} [delete]
+//	@Param			tree_id	path	int	false	"Tree ID"
+//	@Security		Keycloak
 func DeleteTree(svc service.TreeService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()

--- a/internal/server/http/handler/v1/treecluster/handler.go
+++ b/internal/server/http/handler/v1/treecluster/handler.go
@@ -17,24 +17,24 @@ var (
 	treeClusterMapper = generated.TreeClusterHTTPMapperImpl{}
 )
 
-// @Summary		Get all tree clusters
-// @Description	Get all tree clusters
-// @Id				get-all-tree-clusters
-// @Tags			Tree Cluster
-// @Produce		json
-// @Success		200	{object}	entities.TreeClusterListResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/cluster [get]
-// @Param			page		query	string	false	"Page"
-// @Param			limit		query	string	false	"Limit"
-// @Param			status		query	string	false	"watering status (good, moderate, bad)"
-// @Param			region		query	string	false	"region name"
-// @Param			provider	query	string	false	"Provider"
-// @Security		Keycloak
+//	@Summary		Get all tree clusters
+//	@Description	Get all tree clusters
+//	@Id				get-all-tree-clusters
+//	@Tags			Tree Cluster
+//	@Produce		json
+//	@Success		200	{object}	entities.TreeClusterListResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/cluster [get]
+//	@Param			page		query	int		false	"Page"
+//	@Param			limit		query	int		false	"Limit"
+//	@Param			status		query	string	false	"watering status (good, moderate, bad)"
+//	@Param			region		query	string	false	"region name"
+//	@Param			provider	query	string	false	"Provider"
+//	@Security		Keycloak
 func GetAllTreeClusters(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -79,20 +79,20 @@ func fillTreeClusterQueryParams(c *fiber.Ctx) (domain.TreeClusterQuery, error) {
 	return filter, nil
 }
 
-// @Summary		Get tree cluster by ID
-// @Description	Get tree cluster by ID
-// @Id				get-tree-cluster-by-id
-// @Tags			Tree Cluster
-// @Produce		json
-// @Success		200	{object}	entities.TreeClusterResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/cluster/{cluster_id} [get]
-// @Param			cluster_id	path	int	true	"Tree Cluster ID"
-// @Security		Keycloak
+//	@Summary		Get tree cluster by ID
+//	@Description	Get tree cluster by ID
+//	@Id				get-tree-cluster-by-id
+//	@Tags			Tree Cluster
+//	@Produce		json
+//	@Success		200	{object}	entities.TreeClusterResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/cluster/{cluster_id} [get]
+//	@Param			cluster_id	path	int	true	"Tree Cluster ID"
+//	@Security		Keycloak
 func GetTreeClusterByID(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -112,20 +112,20 @@ func GetTreeClusterByID(svc service.TreeClusterService) fiber.Handler {
 	}
 }
 
-// @Summary		Create tree cluster
-// @Description	Create tree cluster
-// @Id				create-tree-cluster
-// @Tags			Tree Cluster
-// @Produce		json
-// @Success		201	{object}	entities.TreeClusterResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/cluster [post]
-// @Param			body	body	entities.TreeClusterCreateRequest	true	"Tree Cluster Create Request"
-// @Security		Keycloak
+//	@Summary		Create tree cluster
+//	@Description	Create tree cluster
+//	@Id				create-tree-cluster
+//	@Tags			Tree Cluster
+//	@Produce		json
+//	@Success		201	{object}	entities.TreeClusterResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/cluster [post]
+//	@Param			body	body	entities.TreeClusterCreateRequest	true	"Tree Cluster Create Request"
+//	@Security		Keycloak
 func CreateTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -146,21 +146,21 @@ func CreateTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	}
 }
 
-// @Summary		Update tree cluster
-// @Description	Update tree cluster
-// @Id				update-tree-cluster
-// @Tags			Tree Cluster
-// @Produce		json
-// @Success		200	{object}	entities.TreeClusterResponse
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/cluster/{cluster_id} [put]
-// @Param			cluster_id	path	int									true	"Tree Cluster ID"
-// @Param			body		body	entities.TreeClusterUpdateRequest	true	"Tree Cluster Update Request"
-// @Security		Keycloak
+//	@Summary		Update tree cluster
+//	@Description	Update tree cluster
+//	@Id				update-tree-cluster
+//	@Tags			Tree Cluster
+//	@Produce		json
+//	@Success		200	{object}	entities.TreeClusterResponse
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/cluster/{cluster_id} [put]
+//	@Param			cluster_id	path	int									true	"Tree Cluster ID"
+//	@Param			body		body	entities.TreeClusterUpdateRequest	true	"Tree Cluster Update Request"
+//	@Security		Keycloak
 func UpdateTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -185,20 +185,20 @@ func UpdateTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	}
 }
 
-// @Summary		Delete tree cluster
-// @Description	Delete tree cluster
-// @Id				delete-tree-cluster
-// @Tags			Tree Cluster
-// @Produce		json
-// @Success		204
-// @Failure		400	{object}	HTTPError
-// @Failure		401	{object}	HTTPError
-// @Failure		403	{object}	HTTPError
-// @Failure		404	{object}	HTTPError
-// @Failure		500	{object}	HTTPError
-// @Router			/v1/cluster/{cluster_id} [delete]
-// @Param			cluster_id	path	int	true	"Tree Cluster ID"
-// @Security		Keycloak
+//	@Summary		Delete tree cluster
+//	@Description	Delete tree cluster
+//	@Id				delete-tree-cluster
+//	@Tags			Tree Cluster
+//	@Produce		json
+//	@Success		204
+//	@Failure		400	{object}	HTTPError
+//	@Failure		401	{object}	HTTPError
+//	@Failure		403	{object}	HTTPError
+//	@Failure		404	{object}	HTTPError
+//	@Failure		500	{object}	HTTPError
+//	@Router			/v1/cluster/{cluster_id} [delete]
+//	@Param			cluster_id	path	int	true	"Tree Cluster ID"
+//	@Security		Keycloak
 func DeleteTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()

--- a/internal/server/http/handler/v1/treecluster/handler.go
+++ b/internal/server/http/handler/v1/treecluster/handler.go
@@ -17,24 +17,24 @@ var (
 	treeClusterMapper = generated.TreeClusterHTTPMapperImpl{}
 )
 
-//	@Summary		Get all tree clusters
-//	@Description	Get all tree clusters
-//	@Id				get-all-tree-clusters
-//	@Tags			Tree Cluster
-//	@Produce		json
-//	@Success		200	{object}	entities.TreeClusterListResponse
-//	@Failure		400	{object}	HTTPError
-//	@Failure		401	{object}	HTTPError
-//	@Failure		403	{object}	HTTPError
-//	@Failure		404	{object}	HTTPError
-//	@Failure		500	{object}	HTTPError
-//	@Router			/v1/cluster [get]
-//	@Param			page		query	int		false	"Page"
-//	@Param			limit		query	int		false	"Limit"
-//	@Param			status		query	string	false	"watering status (good, moderate, bad)"
-//	@Param			region		query	string	false	"region name"
-//	@Param			provider	query	string	false	"Provider"
-//	@Security		Keycloak
+// @Summary		Get all tree clusters
+// @Description	Get all tree clusters
+// @Id				get-all-tree-clusters
+// @Tags			Tree Cluster
+// @Produce		json
+// @Success		200	{object}	entities.TreeClusterListResponse
+// @Failure		400	{object}	HTTPError
+// @Failure		401	{object}	HTTPError
+// @Failure		403	{object}	HTTPError
+// @Failure		404	{object}	HTTPError
+// @Failure		500	{object}	HTTPError
+// @Router			/v1/cluster [get]
+// @Param			page				query	int			false	"Page"
+// @Param			limit				query	int			false	"Limit"
+// @Param			watering_statuses	query	[]string	false	"Watering statuses"
+// @Param			regions				query	[]string	false	"Regions"
+// @Param			provider			query	string		false	"Provider"
+// @Security		Keycloak
 func GetAllTreeClusters(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -61,38 +61,20 @@ func GetAllTreeClusters(svc service.TreeClusterService) fiber.Handler {
 	}
 }
 
-func fillTreeClusterQueryParams(c *fiber.Ctx) (domain.TreeClusterQuery, error) {
-	var filter domain.TreeClusterQuery
-
-	if err := c.QueryParser(&filter); err != nil {
-		return domain.TreeClusterQuery{}, err
-	}
-
-	if c.Query("status") != "" {
-		wateringStatuses, err := domain.ParseWateringStatus(c.Query("status"))
-		if err != nil {
-			return domain.TreeClusterQuery{}, err
-		}
-		filter.WateringStatus = wateringStatuses
-	}
-
-	return filter, nil
-}
-
-//	@Summary		Get tree cluster by ID
-//	@Description	Get tree cluster by ID
-//	@Id				get-tree-cluster-by-id
-//	@Tags			Tree Cluster
-//	@Produce		json
-//	@Success		200	{object}	entities.TreeClusterResponse
-//	@Failure		400	{object}	HTTPError
-//	@Failure		401	{object}	HTTPError
-//	@Failure		403	{object}	HTTPError
-//	@Failure		404	{object}	HTTPError
-//	@Failure		500	{object}	HTTPError
-//	@Router			/v1/cluster/{cluster_id} [get]
-//	@Param			cluster_id	path	int	true	"Tree Cluster ID"
-//	@Security		Keycloak
+// @Summary		Get tree cluster by ID
+// @Description	Get tree cluster by ID
+// @Id				get-tree-cluster-by-id
+// @Tags			Tree Cluster
+// @Produce		json
+// @Success		200	{object}	entities.TreeClusterResponse
+// @Failure		400	{object}	HTTPError
+// @Failure		401	{object}	HTTPError
+// @Failure		403	{object}	HTTPError
+// @Failure		404	{object}	HTTPError
+// @Failure		500	{object}	HTTPError
+// @Router			/v1/cluster/{cluster_id} [get]
+// @Param			cluster_id	path	int	true	"Tree Cluster ID"
+// @Security		Keycloak
 func GetTreeClusterByID(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -112,20 +94,20 @@ func GetTreeClusterByID(svc service.TreeClusterService) fiber.Handler {
 	}
 }
 
-//	@Summary		Create tree cluster
-//	@Description	Create tree cluster
-//	@Id				create-tree-cluster
-//	@Tags			Tree Cluster
-//	@Produce		json
-//	@Success		201	{object}	entities.TreeClusterResponse
-//	@Failure		400	{object}	HTTPError
-//	@Failure		401	{object}	HTTPError
-//	@Failure		403	{object}	HTTPError
-//	@Failure		404	{object}	HTTPError
-//	@Failure		500	{object}	HTTPError
-//	@Router			/v1/cluster [post]
-//	@Param			body	body	entities.TreeClusterCreateRequest	true	"Tree Cluster Create Request"
-//	@Security		Keycloak
+// @Summary		Create tree cluster
+// @Description	Create tree cluster
+// @Id				create-tree-cluster
+// @Tags			Tree Cluster
+// @Produce		json
+// @Success		201	{object}	entities.TreeClusterResponse
+// @Failure		400	{object}	HTTPError
+// @Failure		401	{object}	HTTPError
+// @Failure		403	{object}	HTTPError
+// @Failure		404	{object}	HTTPError
+// @Failure		500	{object}	HTTPError
+// @Router			/v1/cluster [post]
+// @Param			body	body	entities.TreeClusterCreateRequest	true	"Tree Cluster Create Request"
+// @Security		Keycloak
 func CreateTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -146,21 +128,21 @@ func CreateTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	}
 }
 
-//	@Summary		Update tree cluster
-//	@Description	Update tree cluster
-//	@Id				update-tree-cluster
-//	@Tags			Tree Cluster
-//	@Produce		json
-//	@Success		200	{object}	entities.TreeClusterResponse
-//	@Failure		400	{object}	HTTPError
-//	@Failure		401	{object}	HTTPError
-//	@Failure		403	{object}	HTTPError
-//	@Failure		404	{object}	HTTPError
-//	@Failure		500	{object}	HTTPError
-//	@Router			/v1/cluster/{cluster_id} [put]
-//	@Param			cluster_id	path	int									true	"Tree Cluster ID"
-//	@Param			body		body	entities.TreeClusterUpdateRequest	true	"Tree Cluster Update Request"
-//	@Security		Keycloak
+// @Summary		Update tree cluster
+// @Description	Update tree cluster
+// @Id				update-tree-cluster
+// @Tags			Tree Cluster
+// @Produce		json
+// @Success		200	{object}	entities.TreeClusterResponse
+// @Failure		400	{object}	HTTPError
+// @Failure		401	{object}	HTTPError
+// @Failure		403	{object}	HTTPError
+// @Failure		404	{object}	HTTPError
+// @Failure		500	{object}	HTTPError
+// @Router			/v1/cluster/{cluster_id} [put]
+// @Param			cluster_id	path	int									true	"Tree Cluster ID"
+// @Param			body		body	entities.TreeClusterUpdateRequest	true	"Tree Cluster Update Request"
+// @Security		Keycloak
 func UpdateTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -185,20 +167,20 @@ func UpdateTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	}
 }
 
-//	@Summary		Delete tree cluster
-//	@Description	Delete tree cluster
-//	@Id				delete-tree-cluster
-//	@Tags			Tree Cluster
-//	@Produce		json
-//	@Success		204
-//	@Failure		400	{object}	HTTPError
-//	@Failure		401	{object}	HTTPError
-//	@Failure		403	{object}	HTTPError
-//	@Failure		404	{object}	HTTPError
-//	@Failure		500	{object}	HTTPError
-//	@Router			/v1/cluster/{cluster_id} [delete]
-//	@Param			cluster_id	path	int	true	"Tree Cluster ID"
-//	@Security		Keycloak
+// @Summary		Delete tree cluster
+// @Description	Delete tree cluster
+// @Id				delete-tree-cluster
+// @Tags			Tree Cluster
+// @Produce		json
+// @Success		204
+// @Failure		400	{object}	HTTPError
+// @Failure		401	{object}	HTTPError
+// @Failure		403	{object}	HTTPError
+// @Failure		404	{object}	HTTPError
+// @Failure		500	{object}	HTTPError
+// @Router			/v1/cluster/{cluster_id} [delete]
+// @Param			cluster_id	path	int	true	"Tree Cluster ID"
+// @Security		Keycloak
 func DeleteTreeCluster(svc service.TreeClusterService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
@@ -215,4 +197,28 @@ func DeleteTreeCluster(svc service.TreeClusterService) fiber.Handler {
 
 		return c.SendStatus(fiber.StatusNoContent)
 	}
+}
+
+func fillTreeClusterQueryParams(c *fiber.Ctx) (domain.TreeClusterQuery, error) {
+	var filter domain.TreeClusterQuery
+
+	if err := c.QueryParser(&filter); err != nil {
+		return domain.TreeClusterQuery{}, err
+	}
+
+	if c.Query("regions") == "" {
+		filter.Regions = []string{}
+	}
+
+	if c.Query("watering_statuses") != "" {
+		wateringStatuses, err := domain.ParseWateringStatus(c.Query("watering_statuses"))
+		if err != nil {
+			return domain.TreeClusterQuery{}, err
+		}
+		filter.WateringStatuses = wateringStatuses
+	} else {
+		filter.WateringStatuses = []domain.WateringStatus{}
+	}
+
+	return filter, nil
 }

--- a/internal/server/http/handler/v1/treecluster/handler_test.go
+++ b/internal/server/http/handler/v1/treecluster/handler_test.go
@@ -31,7 +31,11 @@ func TestGetAllTreeCluster(t *testing.T) {
 		app.Get("/v1/cluster", handler)
 
 		mockClusterService.EXPECT().GetAll(
-			mock.Anything, entities.TreeClusterQuery{},
+			mock.Anything, entities.TreeClusterQuery{
+				WateringStatuses: []entities.WateringStatus{},
+				Regions:          []string{},
+				Query:            entities.Query{},
+			},
 		).Return(TestClusterList, int64(len(TestClusterList)), nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster", nil)
@@ -63,7 +67,11 @@ func TestGetAllTreeCluster(t *testing.T) {
 		app.Get("/v1/cluster", handler)
 
 		mockClusterService.EXPECT().GetAll(
-			mock.Anything, entities.TreeClusterQuery{},
+			mock.Anything, entities.TreeClusterQuery{
+				WateringStatuses: []entities.WateringStatus{},
+				Regions:          []string{},
+				Query:            entities.Query{},
+			},
 		).Return(TestClusterList, int64(len(TestClusterList)), nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster?page=1&limit=1", nil)
@@ -99,8 +107,11 @@ func TestGetAllTreeCluster(t *testing.T) {
 		app.Get("/v1/cluster", handler)
 
 		mockClusterService.EXPECT().GetAll(
-			mock.Anything,
-			entities.TreeClusterQuery{Query: entities.Query{Provider: "test-provider"}},
+			mock.Anything, entities.TreeClusterQuery{
+				WateringStatuses: []entities.WateringStatus{},
+				Regions:          []string{},
+				Query:            entities.Query{Provider: "test-provider"},
+			},
 		).Return(TestClusterList, int64(len(TestClusterList)), nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster", nil)
@@ -169,7 +180,11 @@ func TestGetAllTreeCluster(t *testing.T) {
 		app.Get("/v1/cluster", handler)
 
 		mockClusterService.EXPECT().GetAll(
-			mock.Anything, entities.TreeClusterQuery{},
+			mock.Anything, entities.TreeClusterQuery{
+				WateringStatuses: []entities.WateringStatus{},
+				Regions:          []string{},
+				Query:            entities.Query{},
+			},
 		).Return([]*entities.TreeCluster{}, int64(0), nil)
 
 		// when
@@ -202,7 +217,11 @@ func TestGetAllTreeCluster(t *testing.T) {
 		app.Get("/v1/cluster", handler)
 
 		mockClusterService.EXPECT().GetAll(
-			mock.Anything, entities.TreeClusterQuery{},
+			mock.Anything, entities.TreeClusterQuery{
+				WateringStatuses: []entities.WateringStatus{},
+				Regions:          []string{},
+				Query:            entities.Query{},
+			},
 		).Return(nil, int64(0), fiber.NewError(fiber.StatusInternalServerError, "service error"))
 
 		// when
@@ -224,19 +243,19 @@ func TestGetAllTreeCluster(t *testing.T) {
 		handler := treecluster.GetAllTreeClusters(mockClusterService)
 		app.Get("/v1/cluster", handler)
 
-		filter := entities.TreeClusterQuery{
-			WateringStatuses: []entities.WateringStatus{entities.WateringStatusModerate},
-		}
-
 		expectedFiltered := []*entities.TreeCluster{
 			TestClusterList[2],
 		}
 
 		mockClusterService.EXPECT().GetAll(
-			mock.Anything, filter,
+			mock.Anything, entities.TreeClusterQuery{
+				WateringStatuses: []entities.WateringStatus{entities.WateringStatusModerate},
+				Regions:          []string{},
+				Query:            entities.Query{},
+			},
 		).Return(expectedFiltered, int64(len(expectedFiltered)), nil)
 
-		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster?status=moderate&page=1&limit=1", nil)
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster?watering_statuses=moderate&page=1&limit=1", nil)
 		resp, err := app.Test(req, -1)
 		defer resp.Body.Close()
 
@@ -270,20 +289,20 @@ func TestGetAllTreeCluster(t *testing.T) {
 		handler := treecluster.GetAllTreeClusters(mockClusterService)
 		app.Get("/v1/cluster", handler)
 
-		filter := entities.TreeClusterQuery{
-			Regions: []string{"Mürwik"},
-		}
-
 		expectedFiltered := []*entities.TreeCluster{
 			TestClusterList[2],
 			TestClusterList[3],
 		}
 
 		mockClusterService.EXPECT().GetAll(
-			mock.Anything, filter,
+			mock.Anything, entities.TreeClusterQuery{
+				WateringStatuses: []entities.WateringStatus{},
+				Regions:          []string{"Mürwik"},
+				Query:            entities.Query{},
+			},
 		).Return(expectedFiltered, int64(len(expectedFiltered)), nil)
 
-		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster?region=Mürwik&page=1&limit=1", nil)
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster?regions=Mürwik&page=1&limit=1", nil)
 		resp, err := app.Test(req, -1)
 		defer resp.Body.Close()
 
@@ -330,7 +349,7 @@ func TestGetAllTreeCluster(t *testing.T) {
 			mock.Anything, filter,
 		).Return(expectedFiltered, int64(len(expectedFiltered)), nil)
 
-		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster?status=moderate&region=Mürwik&page=1&limit=1", nil)
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/cluster?watering_statuses=moderate&regions=Mürwik&page=1&limit=1", nil)
 		resp, err := app.Test(req, -1)
 		defer resp.Body.Close()
 
@@ -393,7 +412,7 @@ func TestGetAllTreeCluster(t *testing.T) {
 		req, _ := http.NewRequestWithContext(
 			context.Background(),
 			http.MethodGet,
-			"/v1/cluster?status=moderate,bad&region=Mürwik,Altstadt&page=1&limit=1",
+			"/v1/cluster?watering_statuses=moderate,bad&regions=Mürwik,Altstadt&page=1&limit=1",
 			nil,
 		)
 		resp, err := app.Test(req, -1)

--- a/internal/server/http/handler/v1/treecluster/handler_test.go
+++ b/internal/server/http/handler/v1/treecluster/handler_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/green-ecolution/green-ecolution-backend/internal/entities"
@@ -224,7 +225,7 @@ func TestGetAllTreeCluster(t *testing.T) {
 		app.Get("/v1/cluster", handler)
 
 		filter := entities.TreeClusterQuery{
-			WateringStatus: []entities.WateringStatus{entities.WateringStatusModerate},
+			WateringStatuses: []entities.WateringStatus{entities.WateringStatusModerate},
 		}
 
 		expectedFiltered := []*entities.TreeCluster{
@@ -270,7 +271,7 @@ func TestGetAllTreeCluster(t *testing.T) {
 		app.Get("/v1/cluster", handler)
 
 		filter := entities.TreeClusterQuery{
-			Region: []string{"Mürwik"},
+			Regions: []string{"Mürwik"},
 		}
 
 		expectedFiltered := []*entities.TreeCluster{
@@ -317,8 +318,8 @@ func TestGetAllTreeCluster(t *testing.T) {
 		app.Get("/v1/cluster", handler)
 
 		filter := entities.TreeClusterQuery{
-			WateringStatus: []entities.WateringStatus{entities.WateringStatusModerate},
-			Region:         []string{"Mürwik"},
+			WateringStatuses: []entities.WateringStatus{entities.WateringStatusModerate},
+			Regions:          []string{"Mürwik"},
 		}
 
 		expectedFiltered := []*entities.TreeCluster{
@@ -375,9 +376,9 @@ func TestGetAllTreeCluster(t *testing.T) {
 		regionNames := []string{"Mürwik", "Altstadt"}
 
 		filter := entities.TreeClusterQuery{
-			WateringStatus: wateringStatues,
-			Region:         regionNames,
-			Query:          entities.Query{Provider: ""},
+			WateringStatuses: wateringStatues,
+			Regions:          regionNames,
+			Query:            entities.Query{Provider: ""},
 		}
 
 		expectedFiltered := []*entities.TreeCluster{

--- a/internal/server/http/handler/v1/treecluster/routes_test.go
+++ b/internal/server/http/handler/v1/treecluster/routes_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/green-ecolution/green-ecolution-backend/internal/entities"
 	"net/http"
 	"testing"
+
+	"github.com/green-ecolution/green-ecolution-backend/internal/entities"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/green-ecolution/green-ecolution-backend/internal/server/http/handler/v1/treecluster"
@@ -28,7 +29,11 @@ func TestRegisterRoutes(t *testing.T) {
 			ctx = context.WithValue(ctx, "limit", int32(-1))
 
 			mockClusterService.EXPECT().GetAll(
-				mock.Anything, entities.TreeClusterQuery{},
+				mock.Anything, entities.TreeClusterQuery{
+					WateringStatuses: []entities.WateringStatus{},
+					Regions:          []string{},
+					Query:            entities.Query{},
+				},
 			).Return(TestClusterList, int64(len(TestClusterList)), nil)
 
 			// when

--- a/internal/storage/postgres/treecluster/get.go
+++ b/internal/storage/postgres/treecluster/get.go
@@ -22,7 +22,7 @@ func (r *TreeClusterRepository) GetAll(ctx context.Context, filter entities.Tree
 	}
 
 	var wateringStatuses []string
-	for _, ws := range filter.WateringStatus {
+	for _, ws := range filter.WateringStatuses {
 		wateringStatuses = append(wateringStatuses, string(ws))
 	}
 
@@ -43,7 +43,7 @@ func (r *TreeClusterRepository) GetAll(ctx context.Context, filter entities.Tree
 
 	rows, err := r.store.GetAllTreeClusters(ctx, &sqlc.GetAllTreeClustersParams{
 		WateringStatus: wateringStatuses,
-		Region:         filter.Region,
+		Region:         filter.Regions,
 		Provider:       filter.Provider,
 		Limit:          limit,
 		Offset:         (page - 1) * limit,
@@ -72,13 +72,13 @@ func (r *TreeClusterRepository) GetAll(ctx context.Context, filter entities.Tree
 func (r *TreeClusterRepository) GetCount(ctx context.Context, filter entities.TreeClusterQuery) (int64, error) {
 	log := logger.GetLogger(ctx)
 	var wateringStatuses []string
-	for _, ws := range filter.WateringStatus {
+	for _, ws := range filter.WateringStatuses {
 		wateringStatuses = append(wateringStatuses, string(ws))
 	}
 
 	totalCount, err := r.store.GetTreeClustersCount(ctx, &sqlc.GetTreeClustersCountParams{
 		WateringStatus: wateringStatuses,
-		Region:         filter.Region,
+		Region:         filter.Regions,
 		Provider:       filter.Provider,
 	})
 	if err != nil {

--- a/internal/storage/postgres/treecluster/get_test.go
+++ b/internal/storage/postgres/treecluster/get_test.go
@@ -186,7 +186,7 @@ func TestTreeClusterRepository_GetAll(t *testing.T) {
 		ctx = context.WithValue(ctx, "limit", int32(-1))
 
 		filter := entities.TreeClusterQuery{
-			WateringStatus: []entities.WateringStatus{entities.WateringStatusGood},
+			WateringStatuses: []entities.WateringStatus{entities.WateringStatusGood},
 		}
 
 		// when
@@ -213,7 +213,7 @@ func TestTreeClusterRepository_GetAll(t *testing.T) {
 		ctx = context.WithValue(ctx, "limit", int32(-1))
 
 		filter := entities.TreeClusterQuery{
-			Region: []string{"Mürwik"},
+			Regions: []string{"Mürwik"},
 		}
 
 		// when
@@ -241,8 +241,8 @@ func TestTreeClusterRepository_GetAll(t *testing.T) {
 		ctx = context.WithValue(ctx, "limit", int32(-1))
 
 		filter := entities.TreeClusterQuery{
-			WateringStatus: []entities.WateringStatus{entities.WateringStatusModerate},
-			Region:         []string{"Mürwik"},
+			WateringStatuses: []entities.WateringStatus{entities.WateringStatusModerate},
+			Regions:          []string{"Mürwik"},
 		}
 
 		// when
@@ -277,9 +277,9 @@ func TestTreeClusterRepository_GetAll(t *testing.T) {
 		regionNames := []string{"Mürwik", "Altstadt"}
 
 		filter := entities.TreeClusterQuery{
-			WateringStatus: wateringstatues,
-			Region:         regionNames,
-			Query:          entities.Query{Provider: ""},
+			WateringStatuses: wateringstatues,
+			Regions:          regionNames,
+			Query:            entities.Query{Provider: ""},
 		}
 
 		// when
@@ -317,9 +317,9 @@ func TestTreeClusterRepository_GetAll(t *testing.T) {
 		regionNames := []string{"Mürwik", "Altstadt"}
 
 		filter := entities.TreeClusterQuery{
-			WateringStatus: wateringstatues,
-			Region:         regionNames,
-			Query:          entities.Query{Provider: ""},
+			WateringStatuses: wateringstatues,
+			Regions:          regionNames,
+			Query:            entities.Query{Provider: ""},
 		}
 
 		// when
@@ -353,12 +353,12 @@ func TestTreeClusterRepository_GetAll(t *testing.T) {
 		ctx = context.WithValue(ctx, "limit", int32(-1))
 
 		filter := entities.TreeClusterQuery{
-			WateringStatus: []entities.WateringStatus{
+			WateringStatuses: []entities.WateringStatus{
 				entities.WateringStatusBad,
 				entities.WateringStatusUnknown,
 			},
-			Region: []string{"DoesNotExist", "FarAwayLand"},
-			Query:  entities.Query{Provider: ""},
+			Regions: []string{"DoesNotExist", "FarAwayLand"},
+			Query:   entities.Query{Provider: ""},
 		}
 
 		// when

--- a/internal/storage/postgres/treecluster/update_test.go
+++ b/internal/storage/postgres/treecluster/update_test.go
@@ -25,7 +25,7 @@ func TestTreeClusterRepository_Update(t *testing.T) {
 			UpdatedAt: time.Now(),
 			Name:      "Mürwik",
 		}
-		now := time.Now()
+		now := time.Now().UTC()
 		lat := 54.3
 		long := 9.5
 
@@ -77,7 +77,7 @@ func TestTreeClusterRepository_Update(t *testing.T) {
 		assert.Equal(t, newRegion.ID, got.Region.ID)
 		assert.Equal(t, newRegion.Name, got.Region.Name)
 		assert.NotNil(t, got.LastWatered)
-		assert.WithinDuration(t, now, *got.LastWatered, time.Second)
+		assert.WithinDuration(t, now, got.LastWatered.UTC(), time.Second)
 		assert.NotNil(t, got.Latitude)
 		assert.NotNil(t, got.Longitude)
 		assert.Equal(t, lat, *got.Latitude)


### PR DESCRIPTION
ref #393 

limit and page should be an `int` in every endpoint, 
and filtering option in the tree_cluster should be arrays