### PR TITLE
feat: add docker compose file to run application locally

### DIFF
--- a/.docker/docker-compose.yaml
+++ b/.docker/docker-compose.yaml
@@ -1,0 +1,99 @@
+services:
+  backend:
+    image: ghcr.io/green-ecolution/green-ecolution-backend-dev:latest # TODO: remove ...-dev when it's ready for production
+    depends_on: 
+      migrations:
+        condition: service_completed_successfully
+    environment:
+      GE_SERVER_APP_URL: "http://localhost:8123"
+      GE_SERVER_PORT: 3000
+      GE_SERVER_DATABASE_HOST: "db"
+      GE_SERVER_DATABASE_PORT: "5432"
+      GE_SERVER_DATABASE_TIMEOUT: "30s"
+      GE_SERVER_DATABASE_NAME: "postgres"
+      GE_SERVER_DATABASE_USER: "postgres"
+      GE_SERVER_DATABASE_PASSWORD: "postgres"
+      GE_MQTT_ENABLE: false 
+      GE_AUTH_ENABLE: false
+      GE_ROUTING_ENABLE: false
+      GE_S3_ENABLE: false 
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.backend.rule=PathPrefix(`/api`)"
+      - "traefik.http.routers.backend.entrypoints=web"
+      - "traefik.http.services.backend.loadbalancer.server.port=3000"
+
+  frontend:
+    image: ghcr.io/green-ecolution/green-ecolution-frontend-dev:latest # TODO: remove ...-dev when it's ready for production
+    depends_on: 
+      backend:
+        condition: service_started
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.frontend.entrypoints=web"
+
+  migrations:
+    image: ghcr.io/green-ecolution/migrations-postgres:latest
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      MIGRATION_WITH_SEED: true
+      MIGRATION_WITH_DB_RESET: true
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+
+  db:
+    image: postgis/postgis
+    restart: always
+    # set shared memory limit when using docker-compose
+    shm_size: 128mb
+    environment:
+        POSTGRES_PASSWORD: postgres
+        POSTGRES_USER: postgres
+        POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+
+  traefik:
+    image: traefik:latest
+    entrypoint: /bin/sh
+    command: >
+      -c "mkdir -p /etc/traefik &&
+      echo \"$$APP_SERVICE\" > /etc/traefik/config.yaml &&
+      exec /entrypoint.sh
+      --api.insecure=true
+      --providers.file.directory=/etc/traefik
+      --providers.docker=true
+      --providers.docker.exposedbydefault=false
+      --entryPoints.web.address=:8123
+      --entryPoints.web.forwardedheaders.insecure=true"
+    environment:
+      APP_SERVICE: |
+          http:
+            services:
+              app:
+                loadBalancer:
+                  servers:
+                  - url: http://host.docker.internal/
+    ports:
+      - "8123:8123"
+      - "8080:8080"
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.app.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.app.entrypoints=web"
+      # TODO: Remove @file on 3.4
+      - "traefik.http.routers.app.service=app@file"
+      - "traefik.http.services.app.loadbalancer.server.url=http://host.docker.internal"


### PR DESCRIPTION
Add a docker compose file to run a demo of the application locally. The mqtt, auth, routing and s3 services will be disabled by default. This file is mentioned in the documentation. 

The compose file will spin up a postgres db and insert the migrations. Then it will start the frontend and backend with traefik as the reverse proxy.